### PR TITLE
added step to commit production compose.yml during release process to /generated, update gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
           docker push --all-tags ghcr.io/aktin/notaufnahme-dwh-wildfly
           docker push --all-tags ghcr.io/aktin/notaufnahme-dwh-httpd
 
+      - name: Commit production compose.yml
+        run: |
+          mkdir -p generated
+          cp src/build/compose.yml generated/compose.yml
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add generated/compose.yml
+          git commit -m "Update generated compose.yml for release ${{ github.ref_name }}" || echo "No changes to commit"
+          git push
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *.iml
 downloads/
 .secrets
+generated/


### PR DESCRIPTION
During releases, the production compose.yml will also now be put into /generated to allow users to track and compare changes across versions