### PR TITLE
Feat/auto sign verify images

### DIFF
--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -52,8 +52,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy images and capture digests
-        id: deploy-and-capture
+      - name: Deploy and sign images
+        id: deploy-and-sign
         run: |
           for SERVICE in database wildfly httpd; do
             IMAGE_NAME=ghcr.io/aktin/notaufnahme-dwh-${SERVICE}

--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -70,12 +70,12 @@ jobs:
             sed -E 's/.*:\$\{[^:]+:-([^}]+)\}/\1/')
           echo "Detected version for ${SERVICE}: $VERSION"
 
-          LATEST_DIGEST=$(docker push $REGISTRY:latest | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
-          VERSION_DIGEST=$(docker push $REGISTRY:$VERSION | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
+          LATEST_DIGEST=$(docker push IMAGE_NAME:latest | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
+          VERSION_DIGEST=$(docker push IMAGE_NAME:$VERSION | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
           echo "Signing $LATEST_DIGEST"
-          cosign sign --yes $REGISTRY@$LATEST_DIGEST
+          cosign sign --yes IMAGE_NAME@$LATEST_DIGEST
           echo "Signing $VERSION_DIGEST"
-          cosign sign --yes $REGISTRY@$VERSION_DIGEST
+          cosign sign --yes IMAGE_NAME@$VERSION_DIGEST
 
       - name: Commit production compose.yml
         run: |

--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -15,6 +15,14 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        services:
+          - name: database
+          - name: wildfly
+          - name: httpd
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -29,6 +37,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y maven
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.4.0
 
       - name: Retrieve Cached Downloads
         uses: actions/cache@v4
@@ -49,11 +60,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy Dockerfiles
+      - name: Deploy and Sign Dockerfiles
         run: |
-          docker push --all-tags ghcr.io/aktin/notaufnahme-dwh-database
-          docker push --all-tags ghcr.io/aktin/notaufnahme-dwh-wildfly
-          docker push --all-tags ghcr.io/aktin/notaufnahme-dwh-httpd
+          SERVICE=${{ matrix.services.name }}
+          IMAGE_NAME=ghcr.io/aktin/notaufnahme-dwh-${SERVICE}
+          
+          # Extract service version safely from prod compose.yml
+          VERSION=$(grep "image: ${IMAGE_NAME}:" src/build/compose.yml | \
+            sed -E 's/.*:\$\{[^:]+:-([^}]+)\}/\1/')
+          echo "Detected version for ${SERVICE}: $VERSION"
+
+          LATEST_DIGEST=$(docker push $REGISTRY:latest | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
+          VERSION_DIGEST=$(docker push $REGISTRY:$VERSION | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
+          echo "Signing $LATEST_DIGEST"
+          cosign sign --yes $REGISTRY@$LATEST_DIGEST
+          echo "Signing $VERSION_DIGEST"
+          cosign sign --yes $REGISTRY@$VERSION_DIGEST
 
       - name: Commit production compose.yml
         run: |

--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y maven
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.4.0
+        uses: sigstore/cosign-installer@v3.9.1
 
       - name: Retrieve Cached Downloads
         uses: actions/cache@v4
@@ -68,6 +68,7 @@ jobs:
             echo "Signing $VERSION_DIGEST"
             cosign sign --yes IMAGE_NAME@$VERSION_DIGEST
           done
+
       - name: Commit production compose.yml
         run: |
           mkdir -p generated

--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -52,21 +52,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy and Sign Dockerfiles
+      - name: Deploy images and capture digests
+        id: deploy-and-capture
         run: |
           for SERVICE in database wildfly httpd; do
             IMAGE_NAME=ghcr.io/aktin/notaufnahme-dwh-${SERVICE}
-
-            # Extract service version safely from prod compose.yml
-            VERSION=$(grep "image: ${IMAGE_NAME}:" src/build/compose.yml | sed -E 's/.*:\$\{[^:]+:-([^}]+)\}/\1/')
-            echo "Detected version for ${SERVICE}: $VERSION"
-  
-            LATEST_DIGEST=$(docker push IMAGE_NAME:latest | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
-            VERSION_DIGEST=$(docker push IMAGE_NAME:$VERSION | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
-            echo "Signing $LATEST_DIGEST"
-            cosign sign --yes IMAGE_NAME@$LATEST_DIGEST
-            echo "Signing $VERSION_DIGEST"
-            cosign sign --yes IMAGE_NAME@$VERSION_DIGEST
+            LATEST_DIGEST=$(docker push --all-tags ${IMAGE_NAME} | tee /dev/stderr | grep -o 'latest: digest: sha256:[a-f0-9]\+' | awk '{print $3}')          
+            cosign sign --yes "${IMAGE_NAME}@${LATEST_DIGEST}"
           done
 
       - name: Commit production compose.yml

--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -15,14 +15,6 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        services:
-          - name: database
-          - name: wildfly
-          - name: httpd
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -62,21 +54,20 @@ jobs:
 
       - name: Deploy and Sign Dockerfiles
         run: |
-          SERVICE=${{ matrix.services.name }}
-          IMAGE_NAME=ghcr.io/aktin/notaufnahme-dwh-${SERVICE}
-          
-          # Extract service version safely from prod compose.yml
-          VERSION=$(grep "image: ${IMAGE_NAME}:" src/build/compose.yml | \
-            sed -E 's/.*:\$\{[^:]+:-([^}]+)\}/\1/')
-          echo "Detected version for ${SERVICE}: $VERSION"
+          for SERVICE in database wildfly httpd; do
+            IMAGE_NAME=ghcr.io/aktin/notaufnahme-dwh-${SERVICE}
 
-          LATEST_DIGEST=$(docker push IMAGE_NAME:latest | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
-          VERSION_DIGEST=$(docker push IMAGE_NAME:$VERSION | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
-          echo "Signing $LATEST_DIGEST"
-          cosign sign --yes IMAGE_NAME@$LATEST_DIGEST
-          echo "Signing $VERSION_DIGEST"
-          cosign sign --yes IMAGE_NAME@$VERSION_DIGEST
-
+            # Extract service version safely from prod compose.yml
+            VERSION=$(grep "image: ${IMAGE_NAME}:" src/build/compose.yml | sed -E 's/.*:\$\{[^:]+:-([^}]+)\}/\1/')
+            echo "Detected version for ${SERVICE}: $VERSION"
+  
+            LATEST_DIGEST=$(docker push IMAGE_NAME:latest | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
+            VERSION_DIGEST=$(docker push IMAGE_NAME:$VERSION | tee /dev/stderr | grep -o 'digest: sha256:[a-f0-9]\+' | awk '{print $2}')
+            echo "Signing $LATEST_DIGEST"
+            cosign sign --yes IMAGE_NAME@$LATEST_DIGEST
+            echo "Signing $VERSION_DIGEST"
+            cosign sign --yes IMAGE_NAME@$VERSION_DIGEST
+          done
       - name: Commit production compose.yml
         run: |
           mkdir -p generated

--- a/.github/workflows/reusable/build-deploy-docker.yml
+++ b/.github/workflows/reusable/build-deploy-docker.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable/check-container-update.yml
+++ b/.github/workflows/reusable/check-container-update.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       update: ${{ steps.compare-digest.outputs.update }}
     steps:

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/aktin/notaufnahme-dwh
 
 3. Verify the signature
 
-Replace `<digest>` with your actual digest:
+Replace `<digest>` with your actual digest. See the [OIDC Cheat Sheet](https://docs.sigstore.dev/quickstart/verification-cheat-sheet/) for more information.
 ```bash
-cosign verify ghcr.io/aktin/notaufnahme-dwh-database@<digest> --certificate-identity="repo:aktin/docker-aktin-dwh" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+cosign verify ghcr.io/aktin/notaufnahme-dwh-database@<digest> --certificate-identity="https://github.com/aktin/docker-aktin-dwh/.github/workflows/WORKFLOW_NAME@refs/heads/BRANCH_NAME" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
 
 If valid, you’ll see output confirming the signature and the trusted GitHub repo. For more information, refer to the [official Documentation](https://docs.sigstore.dev/cosign/verifying/verify/).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,41 @@ docker compose up -d
 ```
 The system will be available at `http://localhost` once all containers have started. For [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/), the property files must be copied manually into the `aktin_config` folder. See [this issue]([https://github.com/aktin/docker-aktin-dwh/issues/6](https://github.com/aktin/docker-aktin-dwh/issues/10)) for details.
 
+### Verification of container signatures
+All our Docker images are signed using [Cosign](https://docs.sigstore.dev/cosign/signing/overview/) with keyless signing. You can check that what you run matches what we built:
+
+1. Check cosign installation
+```bash
+cosign version
+
+# Install if needed:
+# macOS: brew install cosign
+# Linux: curl -sSL https://raw.githubusercontent.com/sigstore/cosign/main/install.sh | sh
+```
+
+2. Get the image digest 
+
+Pull the image first:
+```bash
+docker pull ghcr.io/aktin/notaufnahme-dwh-database:latest
+```
+
+Inspect to find the exact digest:
+```bash
+docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/aktin/notaufnahme-dwh-database:latest
+
+# Example output:
+# ghcr.io/aktin/notaufnahme-dwh-database@sha256:abc123...
+```
+
+3. Verify the signature
+
+Replace `<digest>` with your actual digest:
+```bash
+cosign verify ghcr.io/aktin/notaufnahme-dwh-database@<digest> --certificate-identity="repo:aktin/docker-aktin-dwh" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+If valid, you’ll see output confirming the signature and the trusted GitHub repo. For more information, refer to the [official Documentation](https://docs.sigstore.dev/cosign/verifying/verify/).
 
 ### Running Multiple AKTIN Instances on the Same Server
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ cosign verify ghcr.io/aktin/notaufnahme-dwh-database@<digest> --certificate-iden
 
 If valid, you’ll see output confirming the signature and the trusted GitHub repo. For more information, refer to the [official Documentation](https://docs.sigstore.dev/cosign/verifying/verify/).
 
+Alternatively, you can verify the digest online using the [Rekor Web UI](https://search.sigstore.dev/).
+
 ### Running Multiple AKTIN Instances on the Same Server
 
 To run multiple AKTIN instances on the same server, place instances of `compose.yml` in separate folders and assign unique ports per instance (`HTTP_PORT`). Docker Compose will automatically use the folder name as the project name, isolating container names, networks, and volumes. You can configure the individual instances using `.env` files:

--- a/src/build.sh
+++ b/src/build.sh
@@ -147,7 +147,7 @@ extract_artifacts() {
    extract_src "dwh" "${DWH_GITHUB_TAG}"
 }
 
-execute_build_scripts() {
+execute_deb_build_scripts() {
   echo "Building debian packages"
 
   build_package() {
@@ -374,7 +374,7 @@ main() {
   init_build_environment
   download_artifacts
   extract_artifacts
-  execute_build_scripts
+  execute_deb_build_scripts
   prepare_postgresql_docker
   prepare_apache2_docker "wildfly"
   prepare_wildfly_docker

--- a/src/build.sh
+++ b/src/build.sh
@@ -313,7 +313,6 @@ prepare_docker_compose() {
 
 cleanup_old_docker_images() {
   echo "Cleaning up Docker resources..."
-  # Get all images that match namespace
   local images=$(docker images "${IMAGE_NAMESPACE}-*" --format "{{.Repository}}:{{.Tag}}")
   if [ -n "$images" ]; then
     # Remove any containers using these images
@@ -325,12 +324,32 @@ cleanup_old_docker_images() {
         docker rm -f $containers
       fi
     done
-    # Remove all matching images
-    echo "Removing all matching images..."
+    echo "Removing project images..."
     docker rmi $images
   else
-    echo "No images found to cleanup"
+    echo "No project images found to cleanup"
   fi
+
+  local base_images=(
+    "postgres:${POSTGRESQL_VERSION}"
+    "ubuntu:${UBUNTU_VERSION}"
+    "php:${APACHE_VERSION}"
+  )
+  for base_image in "${base_images[@]}"; do
+    if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^${base_image}$"; then
+      echo "Removing base image ${base_image}..."
+      docker rmi "${base_image}"
+    fi
+  done
+}
+
+pull_base_images() {
+  echo "Pulling base images with Content Trust..."
+  # enabled DCT only allows pulling of signed images
+  export DOCKER_CONTENT_TRUST=1
+  docker pull postgres:${POSTGRESQL_VERSION}
+  docker pull ubuntu:${UBUNTU_VERSION}
+  docker pull php:${APACHE_VERSION}
 }
 
 build_docker_images() {
@@ -380,6 +399,7 @@ main() {
   prepare_wildfly_docker
   prepare_docker_compose
   cleanup_old_docker_images
+  pull_base_images
   build_docker_images
 }
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -345,7 +345,7 @@ cleanup_old_docker_images() {
 
 pull_base_images() {
   echo "Pulling base images with Content Trust..."
-  # enabled DCT only allows pulling of signed images
+  # enabled DCT only allows pulling of signed images from Docker Hub
   export DOCKER_CONTENT_TRUST=1
   docker pull postgres:${POSTGRESQL_VERSION}
   docker pull ubuntu:${UBUNTU_VERSION}


### PR DESCRIPTION
Added signing of our deployed images and a check for signed base images.

For signing, Cosign (see [here](https://www.aikido.dev/blog/top-software-supply-chain-security-tools#top-software-supply-chain-security-tools-in-2025), scroll a bit down) seems to be the preferred way on Github (as [here](https://github.blog/security/supply-chain-security/safeguard-container-signing-capability-actions/) and [here](https://edu.chainguard.dev/open-source/sigstore/cosign/how-to-sign-a-container-with-cosign/#signing-a-container-and-pushing-the-signature-to-a-registry)), with the trend going towards keyless signing.

When using keyless signing, Cosign:
- Grabs the GitHub Actions OIDC identity
- Puts it together with the GitHub repo, workflow name, actor, and commit SHA into a Fulcio (Certificate Authority) certificate (only valid around 10min)
- Stores the certificate with the signature in the registry + Rekor transparency log

Fulcio and Rekor are public benefit services, operated by OpenSSF.  Both are FOSS. Even if the certificate is only valid for 10minutes, verifiers can check the Rekor transparency log to see that 1.) the cert did exist when the signature was made and 2.) the cert matched our identity at that time. That should be enough to assess the validity of the images.

**Side Note**: Docker's native Docker Content Trust (DCT) is build on Notary, which is not available on Github. 

---
### Further ToDos
- [x] `README.md` updates are still missing. Will be done after PR is approved